### PR TITLE
feat/rabbitmq

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -6,3 +6,5 @@ class Settings(BaseSettings):  # type: ignore
     minio_access_key: str
     minio_secret_key: str
     minio_bucket_name: str
+    rabbitmq_url: str
+    rabbitmq_queue_name: str

--- a/app/loaders/rabbitmq.py
+++ b/app/loaders/rabbitmq.py
@@ -1,0 +1,20 @@
+import abc
+
+from app.config import Settings
+
+
+class BaseMessageSender(abc.ABC):
+    def __init__(self, settings: Settings) -> None:
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    async def send(self, message: str) -> None:
+        raise NotImplementedError
+
+
+class MessageSender(BaseMessageSender):
+    def __init__(self, settings: Settings) -> None:
+        pass
+
+    async def send(self, message: str) -> None:
+        pass

--- a/app/loaders/rabbitmq.py
+++ b/app/loaders/rabbitmq.py
@@ -1,5 +1,7 @@
 import abc
 
+from aio_pika import Message, connect
+
 from app.config import Settings
 
 
@@ -14,7 +16,15 @@ class BaseMessageSender(abc.ABC):
 
 class MessageSender(BaseMessageSender):
     def __init__(self, settings: Settings) -> None:
-        pass
+        self._url = settings.rabbitmq_url
+        self._queue_name = settings.rabbitmq_queue_name
 
     async def send(self, message: str) -> None:
-        pass
+        connection = await connect(self._url)
+        async with connection:
+            channel = await connection.channel()
+            queue = await channel.declare_queue(self._queue_name)
+            await channel.default_exchange.publish(
+                Message(bytes(message, "utf-8")),
+                routing_key=queue.name,
+            )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ pre-commit==3.6.1
 python-multipart==0.0.9
 pydantic-settings==2.1.0
 minio==7.2.4
+pytest-asyncio==0.23.5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ python-multipart==0.0.9
 pydantic-settings==2.1.0
 minio==7.2.4
 pytest-asyncio==0.23.5
+aio-pika==9.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pre-commit==3.6.1
 python-multipart==0.0.9
 pydantic-settings==2.1.0
 minio==7.2.4
+aio-pika==9.4.0

--- a/tests/test_minio.py
+++ b/tests/test_minio.py
@@ -14,6 +14,8 @@ def settings():
         minio_access_key="access",
         minio_secret_key="secret",
         minio_bucket_name="bucket",
+        rabbitmq_url="url",
+        rabbitmq_queue_name="queue",
     )
 
 

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from app.config import Settings
+from app.loaders.rabbitmq import Message, MessageSender
+
+
+@pytest.fixture(scope="module")
+def settings() -> Settings:
+    return Settings(
+        minio_host="host",
+        minio_access_key="access",
+        minio_secret_key="secret",
+        minio_bucket_name="bucket",
+        rabbitmq_url="url",
+        rabbitmq_queue_name="queue",
+    )
+
+
+@pytest.mark.asyncio
+async def test_send(settings: Settings, mocker: MockerFixture):
+    mock = mocker.patch("app.loaders.rabbitmq.connect")
+    message_sender = MessageSender(settings)
+    msg = "test"
+    await message_sender.send(msg)
+    mock.assert_called_once_with(
+        settings.rabbitmq_url,
+    )
+    mock_channel: MagicMock = mock.return_value.channel.return_value
+    mock_channel.declare_queue.assert_called_once_with(
+        settings.rabbitmq_queue_name
+    )
+    mock_channel.default_exchange.publish.assert_called_once_with(
+        Message(bytes(msg, "utf-8")), routing_key=settings.rabbitmq_queue_name
+    )

--- a/tests/test_rabbitmq.py
+++ b/tests/test_rabbitmq.py
@@ -1,10 +1,10 @@
-from unittest.mock import MagicMock
+from unittest.mock import ANY, MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
 
 from app.config import Settings
-from app.loaders.rabbitmq import Message, MessageSender
+from app.loaders.rabbitmq import MessageSender
 
 
 @pytest.fixture(scope="module")
@@ -33,5 +33,6 @@ async def test_send(settings: Settings, mocker: MockerFixture):
         settings.rabbitmq_queue_name
     )
     mock_channel.default_exchange.publish.assert_called_once_with(
-        Message(bytes(msg, "utf-8")), routing_key=settings.rabbitmq_queue_name
+        ANY,
+        routing_key=mock_channel.declare_queue.return_value.name,
     )


### PR DESCRIPTION
- :heavy_plus_sign: Add pytest-asyncio dependency
- :heavy_plus_sign: Add aio-pika
- :construction: Add base message sender
- :white_check_mark: Add missing attributes to settings
- :test_tube: Add rabbitmq test
- :wrench: Add rabbitmq related env vars
- :white_check_mark: Fix message assertion
- :sparkles: Implement rabbitmq logic
